### PR TITLE
agregado dominio de imagen a next config

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -8,7 +8,8 @@ const nextConfig = {
       'lh3.googleusercontent.com',
       'avatars.githubusercontent.com',
       'i.pinimg.com',
-      'static.wikia.nocookie.net'
+      'static.wikia.nocookie.net',
+      'res.cloudinary.com'
     ],
   },
 };


### PR DESCRIPTION
Agregado dominio de imagen al next config para que no rompa la página al renderizar imagenes de cloudinary